### PR TITLE
Add a header

### DIFF
--- a/lib/secrets.h
+++ b/lib/secrets.h
@@ -4,5 +4,6 @@
 const char* ssid = "";
 const char* password = "";
 const char* serverName = "";
+const char* apiKey = "";
 
 #endif

--- a/src/functions.ino
+++ b/src/functions.ino
@@ -69,6 +69,7 @@ void post_activity(String uid) {
     HTTPClient http;
     http.begin(String(serverName) + "/activities");
     http.addHeader("Content-Type", "application/json");
+	http.addHeader("Authorization", "Bearer " + String(apiKey));
     String postData = "{\"mac\": \"" + String(macAdr) + "\", \"uid\": \"" + uid + "\"}";
     int statusCode = http.POST(postData);
     if (statusCode == 200) {


### PR DESCRIPTION
This PR is to resolve #3 .

- POST /activitiesについて、secrets.hで宣言したAPIキーをAuthorizationヘッダに含めて送信するように変更。
- GET /newはAuthorizationヘッダを使用せずにアクセス可能になっている。